### PR TITLE
nginx doesn't seems to like recursive location

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -5,6 +5,9 @@ location __PATH__ {
 		rewrite ^ https://$server_name$request_uri? permanent;
 	}
 	try_files $uri @searx;
+
+	# Include SSOWAT user panel.
+	include conf.d/yunohost_panel.conf.inc;
 }
 
 location @searx {
@@ -12,7 +15,4 @@ location @searx {
 	include uwsgi_params;
 	uwsgi_modifier1 30;
 	uwsgi_pass unix:///run/uwsgi/app/searx/socket;
-
-	# Include SSOWAT user panel.
-	include conf.d/yunohost_panel.conf.inc;
 }


### PR DESCRIPTION
Hello,

Was producing this error:

    nginx: [emerg] location "ynhpanel\.(js|json|css)" cannot be inside the named location "@searx" in /etc/nginx/conf.d/yunohost_panel.conf.inc:7

Moving the line in the other location fixed the situation following @opi advice.

This is the result of a modification of upstream yunohost conf https://github.com/YunoHost/yunohost/commit/bb11168c31064d6be6cba3b8f2c48bf3a70f02e8