### PR TITLE
[enh] Fix is_public in lowercase or uppercase.

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -25,10 +25,10 @@ final_path=$(ynh_app_setting_get $app final_path)
 #=================================================
 
 # Fix is_public as a boolean value
-if [ "$is_public,," = "yes" ]; then
+if [ "${is_public,,}" = "yes" ]; then
 	ynh_app_setting_set $app is_public 1
 	is_public=1
-elif [ "$is_public,," = "no" ]; then
+elif [ "${is_public,,}" = "no" ]; then
 	ynh_app_setting_set $app is_public 0
 	is_public=0
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -25,10 +25,10 @@ final_path=$(ynh_app_setting_get $app final_path)
 #=================================================
 
 # Fix is_public as a boolean value
-if [ "$is_public" = "Yes" ]; then
+if [ "$is_public,," = "yes" ]; then
 	ynh_app_setting_set $app is_public 1
 	is_public=1
-elif [ "$is_public" = "No" ]; then
+elif [ "$is_public,," = "no" ]; then
 	ynh_app_setting_set $app is_public 0
 	is_public=0
 fi


### PR DESCRIPTION
## Problem
- *The fix of old is_public value doesn't work if is_public is in lowercase*

## Solution
- *Fix https://github.com/YunoHost-Apps/searx_ynh/issues/24*
- *Compare without considering lowercase or uppercase.*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : JimboJoe
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [ ] **Approval (LGTM)** : 
- [x] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/searx_ynh%20upgrade_lowercase%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/searx_ynh%20upgrade_lowercase%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.