### PR TITLE
Fixes missing python-pybabel dependency

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -55,7 +55,7 @@ ynh_app_setting_set $app is_public $is_public
 # INSTALL DEPENDENCIES
 #=================================================
 
-ynh_install_app_dependencies git build-essential libxslt-dev python-dev python-virtualenv virtualenv python-pybabel zlib1g-dev libffi-dev libssl-dev python-lxml uwsgi uwsgi-plugin-python
+ynh_install_app_dependencies git build-essential libxslt-dev python-dev python-virtualenv virtualenv python-babel zlib1g-dev libffi-dev libssl-dev python-lxml uwsgi uwsgi-plugin-python
 
 #=================================================
 # NGINX CONFIGURATION


### PR DESCRIPTION
Referes to #27 python-pybabel is no longer present in Debian Stretch. python-babel is present instead. python-pybabel is just a transitional package for python-babel[0]. So please let searx_ynh depend on python-babel package instead of python-pybabel.

Thanks

[0] https://packages.debian.org/jessie/python-pybabel