### PR TITLE
App using rm -rf that was unspotted so far ... to be reported as error by the linter

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -123,7 +123,12 @@ ynh_system_user_create --username=$app
 #=================================================
 ynh_script_progression --message="Upgrading Searx..." --weight=7
 
-rm -r $final_path/lib/python2.7/site-packages/setuptools $final_path/lib/python2.7/site-packages/setuptools-*
+ynh_secure_remove $final_path/lib/python2.7/site-packages/setuptools
+for FILE in $final_path/lib/python2.7/site-packages/setuptools-*
+do
+    ynh_secure_remove $FILE
+done
+
 virtualenv --system-site-packages "$final_path"
 set +u; source $final_path/bin/activate; set -u
 pip install -U setuptools


### PR DESCRIPTION
c.f. https://github.com/YunoHost/package_linter/commit/4b513b4cd67275dfc597d30ddbfe1801293ad15a#diff-661c3b5fe67e77caea903b5fdb903b5fb6e8277c912d4a4af94e179ade2910baR1019

This app is using some `rm -rf` or similar command that was unspotted so far ... The app is gonna be capped to level 4 by the CI until this is fixed :/ 