### PR TITLE
Fix updater.sh to correctly retrieve latest version

### DIFF
--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -20,12 +20,8 @@
 current_version=$(cat manifest.json | jq -j '.version|split("~")[0]')
 repo=$(cat manifest.json | jq -j '.upstream.code|split("https://github.com/")[1]')
 # Some jq magic is needed, because the latest upstream release is not always the latest version (e.g. security patches for older versions)
-version=$(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '.[] | select( .prerelease != true ) | .tag_name' | sort -V | tail -1)
+version=$(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '.[] | select( .prerelease != true ) | .tag_name | (if startswith("v") then .[1:] else . end)' | sort -V | tail -1)
 assets=($(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '[ .[] | select(.tag_name=="'$version'").assets[].browser_download_url ] | join(" ") | @sh' | tr -d "'"))
-
-# if [[ ${version:0:1} == "v" || ${version:0:1} == "V" ]]; then
-#     version=${version:1}
-# fi
 
 # Setting up the environment variables
 echo "Current version: $current_version"


### PR DESCRIPTION
## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable): https://github.com/YunoHost-Apps/searx_ynh/runs/4690526251

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
