### PR TITLE
Fix uwsgi config

### DIFF
--- a/conf/uwsgi.ini
+++ b/conf/uwsgi.ini
@@ -23,7 +23,7 @@ base = __FINALPATH__
 route-run = fixpathinfo:
 
 # Module to import
-module = __APP__.webapp
+module = searx.webapp
 
 # Virtualenv and python path
 virtualenv = __FINALPATH__


### PR DESCRIPTION
## Problem

In the `uwsgi.ini` file, the `module` parameter is depending on the name of the application but it shouldn't. The module to be imported is searx.webapp no matter what the name of the application is, and not hardcoding it can lead to problems xhen trying to use custom applications names, or multiple instances.

## Solution

Hardocing the `module` parameter to `searx.webapp` 

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
